### PR TITLE
Fix ulong.SetAt fallback when BMI2 is unavailable (fixes #813)

### DIFF
--- a/src/System/Numerics/BitOperationsExtensions.cs
+++ b/src/System/Numerics/BitOperationsExtensions.cs
@@ -581,27 +581,27 @@ public static partial class BitOperationsExtensions
 				}
 			}
 
-			var (mask, size, @base) = (0x0000FFFFU, 16U, 0U);
-			if (order++ >= PopCount(@this))
+			// Generic fallback when neither BMI2.X64 nor BMI2 is available
+			// (e.g. arm64). The previous binary-search implementation used a
+			// uint mask, which could not reach bits >= 32 of the ulong input
+			// — for inputs with set bits in both the low and high halves it
+			// returned a position from the low half plus the saturating bits
+			// of the unused high-half iterations, instead of the actual
+			// position of the requested set bit.
+			if ((uint)order >= (uint)PopCount(@this))
 			{
 				return -1;
 			}
 
-			while (size > 0)
+			var t = @this;
+			for (var i = 0; t != 0; i++, t &= t - 1)
 			{
-				if (order > PopCount(@this & mask))
+				if (i == order)
 				{
-					@base += size;
-					size >>= 1;
-					mask |= mask << (int)size;
-				}
-				else
-				{
-					size >>= 1;
-					mask >>= (int)size;
+					return TrailingZeroCount(t);
 				}
 			}
-			return @base == FallbackConstants.@long ? -1 : (int)@base;
+			return -1;
 		}
 
 		/// <inheritdoc cref="GetEnumerator(sbyte)"/>


### PR DESCRIPTION
## Summary

Fixes #813.

`extension(ulong @this).SetAt(int order)` had a broken non-BMI2 fallback that used a `uint` mask in a binary-search loop searching a 64-bit input. The mask saturated at `0xFFFFFFFF` and never reached bits 32–63, so `SetAt` returned the wrong position for any `ulong` whose set bits straddle the 32-bit boundary.

```csharp
ulong v = (1UL << 3) | (1UL << 36);
v.SetAt(1);  // returned 31 — should be 36
```

On Apple Silicon (arm64) neither `Bmi2.X64.IsSupported` nor `Bmi2.IsSupported` is true, so this fallback is the only path. The wrong indexer result cascaded through `CellMap`'s indexer into multiple step searchers; `FireworkStepSearcher.GetFireworkDigits` was the most visible victim — it fed the corrupted cell into `(c.AsCellMap() + pivot).SharedLine` which returned the no-shared-line sentinel (32), and `HousesMap[32]` raised `IndexOutOfRangeException`. See #813 for the full impact analysis.

## Approach

The replacement is the standard "walk set bits in ascending order" idiom — `TrailingZeroCount(t)` for the next position, `t &= t - 1` to clear the lowest set bit and advance. O(popcount), at most 64 iterations for a `ulong`, and obviously correct across the full 64-bit range.

```csharp
if ((uint)order >= (uint)PopCount(@this)) return -1;
var t = @this;
for (var i = 0; t != 0; i++, t &= t - 1)
{
    if (i == order) return TrailingZeroCount(t);
}
return -1;
```

The two BMI2 fast paths above the fallback are untouched. The `long.SetAt` overload (which already delegates to `(ulong)@this.SetAt(order)`) picks up the fix transparently. `Int128.SetAt` / `UInt128.SetAt` use a different bit-by-bit loop that's already correct, so they're not touched.

## Verification

Run on macOS 15 / arm64 / .NET 11 SDK `11.0.100-preview.3.26207.106`, built from this branch:

| Corpus | Pre-fix | Post-fix |
|---|---|---|
| 10 puzzles from FPGX SER 9.0–9.2 (Berthier controlled-bias slow band) | 10/10 fail (`ExceptionThrown` from `FireworkStepSearcher.GetFireworkDigits`, or `WrongStep`) | 10/10 solve cleanly |
| 30-puzzle easy/medium regression sample | 30/30 solve | 30/30 solve (identical results — no behaviour change for code paths that didn't exercise the bug) |
| 58 additional puzzles from the same SER 9.0+ band (partial sweep of 200) | (would be 58/58 fail) | 58/58 solve cleanly |

The standalone repro from the issue now returns `36` for `((1UL << 3) | (1UL << 36)).SetAt(1)`.

## Notes

This is the structural sibling of #812. The `CellMap` indexer fallback was the proximate cause of #812; this is the underlying primitive that the indexer (and many other consumers of `ulong.SetAt`) sit on top of. After this lands, the analyzer is reliable on arm64 across the full SE technique catalogue.
